### PR TITLE
Only apply the jaxrs2 filter when we are supplied a Resource

### DIFF
--- a/integrations/jaxrs2/src/main/java/com/expedia/haystack/jaxrs2/filters/ServerFilter.java
+++ b/integrations/jaxrs2/src/main/java/com/expedia/haystack/jaxrs2/filters/ServerFilter.java
@@ -69,7 +69,10 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @return <code>true</code> if this filter should apply to the current context
    */
     protected boolean shouldFilter(ContainerRequestContext context, ResourceInfo resourceInfo) {
-        if (resourceInfo.getResourceMethod().getAnnotation(DisableTracing.class) != null
+        if (resourceInfo == null
+            || resourceInfo.getResourceMethod() == null
+            || resourceInfo.getResourceMethod().getAnnotation(DisableTracing.class) != null
+            || resourceInfo.getResourceClass() == null
             || resourceInfo.getResourceClass().getAnnotation(DisableTracing.class) != null) {
             return false;
         }
@@ -84,17 +87,23 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
      * @return the name used for this operation
      */
     protected String getOperationName(ContainerRequestContext context, ResourceInfo resourceInfo) {
-        final Traced methodAnnotation = resourceInfo.getResourceMethod().getAnnotation(Traced.class);
-        if (methodAnnotation != null) {
-            return methodAnnotation.name();
+        if (resourceInfo.getResourceMethod() != null) {
+            final Traced methodAnnotation = resourceInfo.getResourceMethod().getAnnotation(Traced.class);
+            if (methodAnnotation != null) {
+                return methodAnnotation.name();
+            }
         }
 
-        final Traced classAnnotation = resourceInfo.getResourceClass().getAnnotation(Traced.class);
-        if (classAnnotation != null) {
-            return classAnnotation.name();
+        if (resourceInfo.getResourceClass() != null) {
+            final Traced classAnnotation = resourceInfo.getResourceClass().getAnnotation(Traced.class);
+            if (classAnnotation != null) {
+                return classAnnotation.name();
+            }
+
+            return String.format("%s:%s", context.getMethod(), resourceInfo.getResourceClass().getCanonicalName());
         }
 
-        return String.format("%s:%s", context.getMethod(), resourceInfo.getResourceClass().getCanonicalName());
+        return String.format("%s", context.getMethod());
     }
 
     @Override

--- a/integrations/jaxrs2/src/test/java/com/expedia/haystack/jaxrs2/filters/ServerFilterTest.java
+++ b/integrations/jaxrs2/src/test/java/com/expedia/haystack/jaxrs2/filters/ServerFilterTest.java
@@ -174,7 +174,12 @@ public class ServerFilterTest {
 
     private void test_sad_path(Class<?> resource, String methodName, String method, String url) throws Exception {
         Mockito.<Class<?>>when(resourceInfo.getResourceClass()).thenReturn(resource);
-        when(resourceInfo.getResourceMethod()).thenReturn(resource.getMethod(methodName));
+
+        if (resource != null && methodName != null) {
+            when(resourceInfo.getResourceMethod()).thenReturn(resource.getMethod(methodName));
+        } else {
+            when(resourceInfo.getResourceMethod()).thenReturn(null);
+        }
 
         when(containerRequestContext.getMethod()).thenReturn(method);
 
@@ -202,6 +207,16 @@ public class ServerFilterTest {
     @Test
     public void testDisabledResoureMethod() throws Exception {
         test_sad_path(DisabledResource.class, "get", "GET", "http://localhost/ignoredmethod");
+    }
+
+    @Test
+    public void testMissingResourceClass() throws Exception {
+        test_sad_path(null, null, "GET", "http://localhost/favicon.ico");
+    }
+
+    @Test
+    public void testMissingResourceMethod() throws Exception {
+        test_sad_path(TracedResource.class, null, "GET", "http://localhost/favicon.ico");
     }
 
 }


### PR DESCRIPTION
Only apply the jaxrs2 filter when we are supplied a Resource
- prevent NPE for paths that don't supply either a resource class or method