### PR TITLE
Add dropwizard metrics support for metrics

### DIFF
--- a/core/src/main/java/com/expedia/www/haystack/client/metrics/Tag.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/metrics/Tag.java
@@ -16,6 +16,8 @@
  */
 package com.expedia.www.haystack.client.metrics;
 
+import java.util.Objects;
+
 public class Tag {
     private String key;
     private String value;
@@ -31,6 +33,23 @@ public class Tag {
 
     public String value() {
         return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) { return false; }
+        if (obj == this) { return true; }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        Tag rhs = (Tag) obj;
+        return Objects.equals(key, rhs.key()) &&
+            Objects.equals(value, rhs.value());
     }
 }
 

--- a/examples/dropwizard/micrometer-config.yml
+++ b/examples/dropwizard/micrometer-config.yml
@@ -4,6 +4,8 @@ defaultName: Stranger
 tracer:
   serviceName: HelloWorld
   enabled: true
+  metrics:
+    type: micrometer
   dispatchers:
     - type: logger
       loggerName: dispatcher

--- a/examples/dropwizard/pom.xml
+++ b/examples/dropwizard/pom.xml
@@ -59,17 +59,25 @@
       <version>${version.io.microprofile-opentracing}</version>
     </dependency>
 
-    <!-- Metrics for haystack-client -->
+    <!-- Dropwizard based metrics for haystack-client -->
+    <dependency>
+      <groupId>com.expedia.www</groupId>
+      <artifactId>haystack-client-dropwizard-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Micrometer based metrics for haystack-client -->
     <dependency>
       <groupId>com.expedia.www</groupId>
       <artifactId>haystack-client-micrometer</artifactId>
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Explicitly pull in a version of the base provider because marked optional -->
+    <!-- Explicitly pull in a provider for micrometer-->
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
+      <artifactId>micrometer-registry-jmx</artifactId>
+      <version>${micrometer.version}</version>
     </dependency>
 
       <dependency>

--- a/integrations/dropwizard-metrics/pom.xml
+++ b/integrations/dropwizard-metrics/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.expedia.www</groupId>
+    <artifactId>haystack-client-java-integrations</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>haystack-client-dropwizard-metrics</artifactId>
+  <packaging>jar</packaging>
+  <name>haystack-client-dropwizard-metrics</name>
+  <description>Dropwizard metrics for the haystack library</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.expedia.www</groupId>
+      <artifactId>haystack-client-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardCounter.java
+++ b/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardCounter.java
@@ -14,19 +14,30 @@
  *       limitations under the License.
  *
  */
-package com.expedia.haystack.dropwizard.configuration;
+package com.expedia.www.haystack.client.metrics.dropwizard;
 
-import com.expedia.www.haystack.client.dispatchers.Dispatcher;
-import com.expedia.www.haystack.client.metrics.MetricsRegistry;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.codahale.metrics.Meter;
+import com.expedia.www.haystack.client.metrics.Counter;
 
-import io.dropwizard.jackson.Discoverable;
-import io.dropwizard.setup.Environment;
+public class DropwizardCounter implements Counter {
+    private final Meter delegate;
 
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
-public interface DispatcherFactory extends Discoverable {
+    public DropwizardCounter(Meter delegate) {
+        this.delegate = delegate;
+    }
 
-    Dispatcher build(Environment environment, MetricsRegistry metrics);
+    @Override
+    public void increment(double amount) {
+        delegate.mark((long) amount);
+    }
+
+    @Override
+    public void decrement(double amount) {
+        delegate.mark((long) (-1 * amount));
+    }
+
+    @Override
+    public double count() {
+        return delegate.getCount();
+    }
 }

--- a/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardGauge.java
+++ b/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardGauge.java
@@ -14,27 +14,19 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.dropwizard;
 
-public class MicrometerCounter implements Counter {
-    private final io.micrometer.core.instrument.Counter delegate;
+import com.expedia.www.haystack.client.metrics.Gauge;
 
-    public MicrometerCounter(io.micrometer.core.instrument.Counter delegate) {
+public class DropwizardGauge implements Gauge {
+    private final com.codahale.metrics.Gauge<Double> delegate;
+
+    public DropwizardGauge(com.codahale.metrics.Gauge<Double> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public void increment(double amount) {
-        delegate.increment(amount);
-    }
-
-    @Override
-    public void decrement(double amount) {
-        increment(-1 * amount);
-    }
-
-    @Override
-    public double count() {
-        return delegate.count();
+    public double value() {
+        return delegate.getValue();
     }
 }

--- a/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardMetricsRegistry.java
+++ b/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardMetricsRegistry.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.client.metrics.dropwizard;
+
+import java.util.Collection;
+import java.util.function.ToDoubleFunction;
+
+import com.codahale.metrics.MetricRegistry;
+import com.expedia.www.haystack.client.metrics.Counter;
+import com.expedia.www.haystack.client.metrics.Gauge;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
+import com.expedia.www.haystack.client.metrics.Tag;
+import com.expedia.www.haystack.client.metrics.Timer;
+
+public class DropwizardMetricsRegistry implements MetricsRegistry {
+    private final MetricRegistry registry;
+    private final NameMapper nameMapper;
+
+    public DropwizardMetricsRegistry(MetricRegistry registry, NameMapper nameMapper) {
+        this.registry = registry;
+        this.nameMapper = nameMapper;
+    }
+
+    @Override
+    public <T> Gauge gauge(String name, Collection<Tag> tags, T obj, ToDoubleFunction<T> f) {
+        com.codahale.metrics.Gauge<Double> gauge = () -> {
+            if (obj != null) {
+                return f.applyAsDouble(obj);
+            }
+            return Double.NaN;
+        };
+        registry.register(nameMapper.toName(name, tags), gauge);
+        return new DropwizardGauge(gauge);
+    }
+
+    @Override
+    public Counter counter(String name, Collection<Tag> tags) {
+        return new DropwizardCounter(registry.meter(nameMapper.toName(name, tags)));
+    }
+
+    @Override
+    public Timer timer(String name, Collection<Tag> tags) {
+        return new DropwizardTimer(registry.timer(nameMapper.toName(name, tags)));
+    }
+}

--- a/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardTimer.java
+++ b/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/DropwizardTimer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.client.metrics.dropwizard;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.expedia.www.haystack.client.metrics.Timer;
+
+public class DropwizardTimer implements Timer {
+    private final com.codahale.metrics.Timer delegate;
+    private final AtomicLong totalTime = new AtomicLong(0);
+
+    public DropwizardTimer(com.codahale.metrics.Timer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public double totalTime(TimeUnit unit) {
+        return unit.convert(totalTime.get(), TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public long count() {
+        return delegate.getCount();
+    }
+
+    @Override
+    public void record(long duration, TimeUnit unit) {
+        delegate.update(duration, unit);
+        totalTime.addAndGet(TimeUnit.NANOSECONDS.convert(duration, unit));
+    }
+
+    @Override
+    public Sample start() {
+        return new DropwizardTimerSample(delegate.time());
+    }
+
+    public static class DropwizardTimerSample implements Timer.Sample {
+        private final com.codahale.metrics.Timer.Context delegate;
+
+        public DropwizardTimerSample(com.codahale.metrics.Timer.Context delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long stop() {
+            return delegate.stop();
+        }
+    }
+}

--- a/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/NameMapper.java
+++ b/integrations/dropwizard-metrics/src/main/java/com/expedia/www/haystack/client/metrics/dropwizard/NameMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.client.metrics.dropwizard;
+
+import java.util.Collection;
+import java.util.Comparator;
+
+import com.codahale.metrics.MetricRegistry;
+import com.expedia.www.haystack.client.metrics.Tag;
+
+/**
+ * Define how to map to convert name and tags into a dropwizard style name
+ */
+public interface NameMapper {
+
+    /**
+     * Convert tagged metrics, with natural sorting, into dot seperated
+     * names, e.g. {@code com.expedia.www.haystack.client.Tracer.flush.state.exception}
+     */
+    NameMapper DEFAULT = (name, tags) -> {
+        String descriptors = new String();
+        if (tags != null && !tags.isEmpty()) {
+            descriptors = tags.stream()
+                .sorted(Comparator.comparing(Tag::key))
+                .map(t -> MetricRegistry.name(t.key(), t.value()))
+                .reduce("", MetricRegistry::name);
+        }
+
+        return MetricRegistry.name(name, descriptors).replaceAll("[ ]", "_");
+    };
+
+    String toName(String name, Collection<Tag> tags);
+}

--- a/integrations/dropwizard/pom.xml
+++ b/integrations/dropwizard/pom.xml
@@ -15,10 +15,6 @@
   <name>haystack-client-dropwizard</name>
   <description>Dropwizard bindings for the client</description>
 
-  <properties>
-    <dropwizard.version>1.2.2</dropwizard.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -57,8 +53,20 @@
     </dependency>
 
     <dependency>
+      <groupId>com.expedia.www</groupId>
+      <artifactId>haystack-client-dropwizard-metrics</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-noop</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-core</artifactId>
     </dependency>
 
     <dependency>

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/AgentClientFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/AgentClientFactory.java
@@ -27,8 +27,11 @@ import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.client.dispatchers.clients.Client;
 import com.expedia.www.haystack.client.dispatchers.clients.GRPCAgentClient;
 import com.expedia.www.haystack.client.dispatchers.formats.Format;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.setup.Environment;
 
 /**
  * A factory for configuring and building {@link GRPCAgentClient} instances.
@@ -105,9 +108,9 @@ public class AgentClientFactory extends BaseClientFactory {
     }
 
     @Override
-    public Client build() {
-        GRPCAgentClient.Builder grpcBuilder = new GRPCAgentClient.Builder(getMetrics().build(), host, port);
-        grpcBuilder.withFormat((Format<Span>) getFormat().build());
+    public Client build(Environment environment, MetricsRegistry metrics) {
+        GRPCAgentClient.Builder grpcBuilder = new GRPCAgentClient.Builder(metrics, host, port);
+        grpcBuilder.withFormat((Format<Span>) getFormat().build(environment));
 
         if (keepAliveTimeMS != null) {
             grpcBuilder.withKeepAliveTimeMS(keepAliveTimeMS);

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/BaseClientFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/BaseClientFactory.java
@@ -23,20 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public abstract class BaseClientFactory implements ClientFactory {
 
     @NotNull
-    protected MetricsFactory metrics = new NoopMetricsFactory();
-
-    @NotNull
     protected FormatFactory format;
-
-    @JsonProperty
-    public MetricsFactory getMetrics() {
-        return metrics;
-    }
-
-    @JsonProperty
-    public void setMetrics(MetricsFactory metrics) {
-        this.metrics = metrics;
-    }
 
     /**
      * @return the format

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/ClientFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/ClientFactory.java
@@ -17,13 +17,15 @@
 package com.expedia.haystack.dropwizard.configuration;
 
 import com.expedia.www.haystack.client.dispatchers.clients.Client;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.setup.Environment;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public interface ClientFactory extends Discoverable {
-    Client build();
+    Client build(Environment environment, MetricsRegistry metrics);
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/DropwizardMetricsFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/DropwizardMetricsFactory.java
@@ -16,17 +16,28 @@
  */
 package com.expedia.haystack.dropwizard.configuration;
 
-import com.expedia.www.haystack.client.dispatchers.Dispatcher;
-import com.expedia.www.haystack.client.metrics.MetricsRegistry;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import javax.annotation.Nullable;
 
-import io.dropwizard.jackson.Discoverable;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
+import com.expedia.www.haystack.client.metrics.dropwizard.DropwizardMetricsRegistry;
+import com.expedia.www.haystack.client.metrics.dropwizard.NameMapper;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.dropwizard.setup.Environment;
 
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
-public interface DispatcherFactory extends Discoverable {
+/**
+ * A factory for configuring and building {@link DropwizardMetricsRegistry} instances.
+ *
+ * See {@link MetricsFactory} for more options, if any.
+ */
+@JsonTypeName("dropwizard")
+public class DropwizardMetricsFactory implements MetricsFactory {
 
-    Dispatcher build(Environment environment, MetricsRegistry metrics);
+    @Nullable
+    private NameMapper nameMapper = NameMapper.DEFAULT;
+
+    @Override
+    public MetricsRegistry build(Environment environment) {
+        return new DropwizardMetricsRegistry(environment.metrics(), nameMapper);
+    }
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/FormatFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/FormatFactory.java
@@ -22,10 +22,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.setup.Environment;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public interface FormatFactory extends Discoverable {
 
-    Format<?> build();
+    Format<?> build(Environment environment);
 
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/LoggerClientFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/LoggerClientFactory.java
@@ -20,12 +20,15 @@ import javax.annotation.Nullable;
 
 import com.expedia.www.haystack.client.dispatchers.clients.Client;
 import com.expedia.www.haystack.client.dispatchers.clients.LoggerClient;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 /**
  * A factory for configuring and building {@link LoggerClient} instances.
- * 
+ *
  * Configaruation for the logger used is possible; by default it uses the logger for the {@link LoggerClient}.
  *
  * See {@link BaseClientFactory} for more options, if any.
@@ -42,8 +45,8 @@ public class LoggerClientFactory extends BaseClientFactory {
     }
 
     @Override
-    public Client build() {
-        LoggerClient.Builder builder = new LoggerClient.Builder(getMetrics().build(), getFormat().build());
+    public Client build(Environment environment, MetricsRegistry metrics) {
+        LoggerClient.Builder builder = new LoggerClient.Builder(metrics, getFormat().build(environment));
         if (loggerName != null) {
             builder.withLogger(loggerName);
         }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/LoggerDispatcherFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/LoggerDispatcherFactory.java
@@ -21,38 +21,26 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.expedia.www.haystack.client.dispatchers.LoggerDispatcher;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 @JsonTypeName("logger")
 public class LoggerDispatcherFactory implements DispatcherFactory {
-
-    @NotNull
-    @Valid
-    private MetricsFactory metrics = new NoopMetricsFactory();
-
     @Nullable
     private String loggerName;
 
     @Override
-    public LoggerDispatcher build() {
-        LoggerDispatcher.Builder loggerBuilder = new LoggerDispatcher.Builder(metrics.build());
+    public LoggerDispatcher build(Environment environment, MetricsRegistry metrics) {
+        LoggerDispatcher.Builder loggerBuilder = new LoggerDispatcher.Builder(metrics);
 
         if (loggerName != null) {
             loggerBuilder.withLogger(loggerName);
         }
 
         return loggerBuilder.build();
-    }
-
-    @JsonProperty
-    public MetricsFactory getMetrics() {
-        return metrics;
-    }
-
-    @JsonProperty
-    public void setMetrics(MetricsFactory metrics) {
-        this.metrics = metrics;
     }
 
     /**

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/MetricsFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/MetricsFactory.java
@@ -22,8 +22,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.setup.Environment;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public interface MetricsFactory extends Discoverable {
-    MetricsRegistry build();
+    MetricsRegistry build(Environment environment);
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/MicrometerMetricsFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/MicrometerMetricsFactory.java
@@ -16,10 +16,12 @@
  */
 package com.expedia.haystack.dropwizard.configuration;
 
-import com.expedia.www.haystack.client.metrics.GlobalMetricsRegistry;
 import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.expedia.www.haystack.client.metrics.NoopMetricsRegistry;
+import com.expedia.www.haystack.client.metrics.micrometer.GlobalMetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.setup.Environment;
 
 /**
  * A factory for configuring and building {@link NoopMetricsRegistry} instances.
@@ -32,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class MicrometerMetricsFactory implements MetricsFactory {
 
     @Override
-    public MetricsRegistry build() {
+    public MetricsRegistry build(Environment environment) {
         return new GlobalMetricsRegistry();
     }
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopClientFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopClientFactory.java
@@ -18,11 +18,14 @@ package com.expedia.haystack.dropwizard.configuration;
 
 import com.expedia.www.haystack.client.dispatchers.clients.Client;
 import com.expedia.www.haystack.client.dispatchers.clients.NoopClient;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.setup.Environment;
 
 /**
  * A factory for configuring and building {@link NoopClient} instances.
- * 
+ *
  * All configaruation is ignored by the client.
  *
  * See {@link BaseClientFactory} for more options, if any.
@@ -37,7 +40,7 @@ public class NoopClientFactory extends BaseClientFactory {
     }
 
 	@Override
-	public Client build() {
+	public Client build(Environment environment, MetricsRegistry metrics) {
       return new NoopClient();
 	}
 

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopDispatcherFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopDispatcherFactory.java
@@ -18,13 +18,16 @@ package com.expedia.haystack.dropwizard.configuration;
 
 import com.expedia.www.haystack.client.dispatchers.Dispatcher;
 import com.expedia.www.haystack.client.dispatchers.NoopDispatcher;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.setup.Environment;
 
 @JsonTypeName("noop")
 public class NoopDispatcherFactory implements DispatcherFactory {
 
     @Override
-    public Dispatcher build() {
+    public Dispatcher build(Environment environment, MetricsRegistry metrics) {
         return new NoopDispatcher();
     }
 

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopMetricsFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/NoopMetricsFactory.java
@@ -20,6 +20,8 @@ import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.expedia.www.haystack.client.metrics.NoopMetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 /**
  * A factory for configuring and building {@link NoopMetricsRegistry} instances.
  *
@@ -31,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class NoopMetricsFactory implements MetricsFactory {
 
     @Override
-    public MetricsRegistry build() {
+    public MetricsRegistry build(Environment environment) {
         return new NoopMetricsRegistry();
     }
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/ProtoBufFormatFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/ProtoBufFormatFactory.java
@@ -20,9 +20,12 @@ import com.expedia.www.haystack.client.dispatchers.formats.Format;
 import com.expedia.www.haystack.client.dispatchers.formats.ProtoBufFormat;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 @JsonTypeName("protobuf")
 public class ProtoBufFormatFactory implements FormatFactory {
-    public Format<?> build() {
+    @Override
+    public Format<?> build(Environment environment) {
         return new ProtoBufFormat();
     }
 }

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/RemoteDispatcherFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/RemoteDispatcherFactory.java
@@ -23,16 +23,14 @@ import javax.validation.constraints.NotNull;
 
 import com.expedia.www.haystack.client.dispatchers.Dispatcher;
 import com.expedia.www.haystack.client.dispatchers.RemoteDispatcher;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 @JsonTypeName("remote")
 public class RemoteDispatcherFactory implements DispatcherFactory {
-
-    @Valid
-    @NotNull
-    private MetricsFactory metrics = new NoopMetricsFactory();
-
     @Valid
     @NotNull
     private ClientFactory client;
@@ -54,8 +52,8 @@ public class RemoteDispatcherFactory implements DispatcherFactory {
     private Long shutdownTimoutMs;
 
     @Override
-    public Dispatcher build() {
-        RemoteDispatcher.Builder builder = new RemoteDispatcher.Builder(metrics.build(), client.build());
+    public Dispatcher build(Environment environment, MetricsRegistry metrics) {
+        RemoteDispatcher.Builder builder = new RemoteDispatcher.Builder(metrics, client.build(environment, metrics));
         if (maxQueueSize != null) {
             builder.withBlockingQueueLimit(maxQueueSize);
         }
@@ -69,16 +67,6 @@ public class RemoteDispatcherFactory implements DispatcherFactory {
             builder.withShutdownTimeoutMillis(shutdownTimoutMs);
         }
         return builder.build();
-    }
-
-    @JsonProperty
-    public MetricsFactory getMetrics() {
-        return metrics;
-    }
-
-    @JsonProperty
-    public void setMetrics(MetricsFactory metrics) {
-        this.metrics = metrics;
     }
 
     /**

--- a/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/StringFormatFactory.java
+++ b/integrations/dropwizard/src/main/java/com/expedia/haystack/dropwizard/configuration/StringFormatFactory.java
@@ -20,9 +20,12 @@ import com.expedia.www.haystack.client.dispatchers.formats.Format;
 import com.expedia.www.haystack.client.dispatchers.formats.StringFormat;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.dropwizard.setup.Environment;
+
 @JsonTypeName("string")
 public class StringFormatFactory implements FormatFactory {
-    public Format<?> build() {
+    @Override
+    public Format<?> build(Environment environment) {
         return new StringFormat();
     }
 }

--- a/integrations/dropwizard/src/main/resources/META-INF/services/com.expedia.haystack.dropwizard.configuration.MetricsFactory
+++ b/integrations/dropwizard/src/main/resources/META-INF/services/com.expedia.haystack.dropwizard.configuration.MetricsFactory
@@ -1,2 +1,3 @@
 com.expedia.haystack.dropwizard.configuration.NoopMetricsFactory
 com.expedia.haystack.dropwizard.configuration.MicrometerMetricsFactory
+com.expedia.haystack.dropwizard.configuration.DropwizardMetricsFactory

--- a/integrations/dropwizard/src/test/java/com/expedia/haystack/dropwizard/configuration/MetricsFactoryTest.java
+++ b/integrations/dropwizard/src/test/java/com/expedia/haystack/dropwizard/configuration/MetricsFactoryTest.java
@@ -41,5 +41,9 @@ public class MetricsFactoryTest extends BaseFactoryTest<MetricsFactory> {
     public void testMicrometerMetricsFactory() throws Exception {
         testFactory(factory, "yaml/metrics/micrometer.yml", MicrometerMetricsFactory.class);
     }
-}
 
+    @Test
+    public void testDropwizardMetricsFactory() throws Exception {
+        testFactory(factory, "yaml/metrics/dropwizard.yml", DropwizardMetricsFactory.class);
+    }
+}

--- a/integrations/dropwizard/src/test/resources/yaml/metrics/dropwizard.yml
+++ b/integrations/dropwizard/src/test/resources/yaml/metrics/dropwizard.yml
@@ -1,0 +1,1 @@
+type: dropwizard

--- a/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/GlobalMetricsRegistry.java
+++ b/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/GlobalMetricsRegistry.java
@@ -14,19 +14,13 @@
  *       limitations under the License.
  *
  */
-package com.expedia.haystack.dropwizard.configuration;
+package com.expedia.www.haystack.client.metrics.micrometer;
 
-import com.expedia.www.haystack.client.dispatchers.Dispatcher;
-import com.expedia.www.haystack.client.metrics.MetricsRegistry;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.micrometer.core.instrument.Metrics;
 
-import io.dropwizard.jackson.Discoverable;
-import io.dropwizard.setup.Environment;
+public class GlobalMetricsRegistry extends MicrometerMetricsRegistry {
 
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
-public interface DispatcherFactory extends Discoverable {
-
-    Dispatcher build(Environment environment, MetricsRegistry metrics);
+    public GlobalMetricsRegistry() {
+        super(Metrics.globalRegistry);
+    }
 }

--- a/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerCounter.java
+++ b/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerCounter.java
@@ -14,13 +14,29 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.micrometer;
 
-import io.micrometer.core.instrument.Metrics;
+import com.expedia.www.haystack.client.metrics.Counter;
 
-public class GlobalMetricsRegistry extends MicrometerMetricsRegistry {
+public class MicrometerCounter implements Counter {
+    private final io.micrometer.core.instrument.Counter delegate;
 
-    public GlobalMetricsRegistry() {
-        super(Metrics.globalRegistry);
+    public MicrometerCounter(io.micrometer.core.instrument.Counter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void increment(double amount) {
+        delegate.increment(amount);
+    }
+
+    @Override
+    public void decrement(double amount) {
+        increment(-1 * amount);
+    }
+
+    @Override
+    public double count() {
+        return delegate.count();
     }
 }

--- a/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerGauge.java
+++ b/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerGauge.java
@@ -14,7 +14,9 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.micrometer;
+
+import com.expedia.www.haystack.client.metrics.Gauge;
 
 public class MicrometerGauge<T> implements Gauge {
     private final io.micrometer.core.instrument.Gauge delegate;

--- a/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerMetricsRegistry.java
+++ b/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerMetricsRegistry.java
@@ -14,13 +14,18 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.micrometer;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
+
+import com.expedia.www.haystack.client.metrics.Counter;
+import com.expedia.www.haystack.client.metrics.Gauge;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
+import com.expedia.www.haystack.client.metrics.Tag;
+import com.expedia.www.haystack.client.metrics.Timer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 

--- a/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerTimer.java
+++ b/integrations/micrometer/src/main/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerTimer.java
@@ -14,9 +14,11 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.micrometer;
 
 import java.util.concurrent.TimeUnit;
+
+import com.expedia.www.haystack.client.metrics.Timer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 

--- a/integrations/micrometer/src/test/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerMetricsRegistryTest.java
+++ b/integrations/micrometer/src/test/java/com/expedia/www/haystack/client/metrics/micrometer/MicrometerMetricsRegistryTest.java
@@ -14,13 +14,18 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.client.metrics;
+package com.expedia.www.haystack.client.metrics.micrometer;
 
 import static java.util.Collections.emptyList;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+
+import com.expedia.www.haystack.client.metrics.Counter;
+import com.expedia.www.haystack.client.metrics.Gauge;
+import com.expedia.www.haystack.client.metrics.MetricsRegistry;
+import com.expedia.www.haystack.client.metrics.Timer;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -17,8 +17,32 @@
 
     <name>Client integrations for Haystack.</name>
 
+    <properties>
+      <dropwizard.version>1.2.2</dropwizard.version>
+      <dropwizard-metrics.version>4.0.2</dropwizard-metrics.version>
+    </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-bom</artifactId>
+        <version>${dropwizard.version}</version>
+        <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${dropwizard-metrics.version}</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
     <modules>
       <module>dropwizard</module>
+      <module>dropwizard-metrics</module>
       <module>micrometer</module>
     </modules>
 </project>


### PR DESCRIPTION
- Update the example application to use both flavors of metrics
- Update dropwizard integration for using the built-in metrics by default
- Cleaned up configuration to reuse the registry configurated at the top most element
- Moved micrometer into it's own package namespace