### PR TITLE
Relocate artifacts that are problematic

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,4 +88,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+    <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
   </properties>
@@ -264,6 +265,44 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <transformers>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                </transformers>
+                <relocations>
+                  <relocation>
+                    <pattern>io.netty</pattern>
+                    <shadedPattern>haystack.io.netty</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.opencensus</pattern>
+                    <shadedPattern>haystack.io.opencensus</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>com.google</pattern>
+                    <shadedPattern>haystack.com.google</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.grpc</pattern>
+                    <shadedPattern>haystack.io.grpc</shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>${maven-source-plugin.version}</version>
           <executions>
@@ -375,6 +414,10 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
           </plugin>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -416,10 +416,6 @@
             <artifactId>maven-release-plugin</artifactId>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-          </plugin>
-          <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <micrometer.version>1.0.1</micrometer.version>
 
     <!--Plugin Properties -->
-    <maven-jacoco-plugin.version>0.7.9</maven-jacoco-plugin.version>
+    <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-protobuf-plugin.version>3.3.0.1</maven-protobuf-plugin.version>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <scope>provided</scope>
         </dependency>
 
       <dependency>
@@ -36,6 +35,10 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The following package roots are relocated to a `haystack` namespace:
- io.netty
- io.opencensus
- com.google
- io.grpc