### PR TITLE
making propagation keys case insensitive

### DIFF
--- a/core/src/main/java/com/expedia/www/haystack/client/propagation/DefaultKeyConvention.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/propagation/DefaultKeyConvention.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-public class DefaultKeyConvention implements KeyConvention {
+public final class DefaultKeyConvention implements KeyConvention {
 
     private static final String BAGGAGE_PREFIX = "Baggage-";
 

--- a/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
@@ -78,16 +78,17 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
         final Map<String, String> baggage = new HashMap<>();
 
         for (Map.Entry<String, String> entry : carrier) {
-            final String decodedKey = keyCodex.decode(entry.getKey()).toLowerCase();
+            final String decodedKey = keyCodex.decode(entry.getKey());
+            final String decodedKeyLowerCase = decodedKey.toLowerCase();
 
-            if (decodedKey.startsWith(convention.baggagePrefix().toLowerCase(Locale.ROOT))) {
+            if (decodedKeyLowerCase.startsWith(convention.baggagePrefix().toLowerCase(Locale.ROOT))) {
                 baggage.put(decodedKey.substring(convention.baggagePrefix().length()),
                             valueCodex.decode(entry.getValue()));
-            } else if (containsIgnoreCase(convention.traceIdKeyAliases(), decodedKey)) {
+            } else if (containsIgnoreCase(convention.traceIdKeyAliases(), decodedKeyLowerCase)) {
                 traceId = valueCodex.decode(entry.getValue());
-            } else if (containsIgnoreCase(convention.parentIdKeyAliases(), decodedKey)) {
+            } else if (containsIgnoreCase(convention.parentIdKeyAliases(), decodedKeyLowerCase)) {
                 parentId = valueCodex.decode(entry.getValue());
-            } else if (containsIgnoreCase(convention.spanIdKeyAliases(), decodedKey)) {
+            } else if (containsIgnoreCase(convention.spanIdKeyAliases(), decodedKeyLowerCase)) {
                 spanId = valueCodex.decode(entry.getValue());
             }
         }

--- a/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
@@ -18,10 +18,12 @@ package com.expedia.www.haystack.client.propagation;
 
 import com.expedia.www.haystack.client.SpanContext;
 import io.opentracing.propagation.TextMap;
+import java.util.Collection;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -50,17 +52,6 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
         return String.format("%s%s", prefix, key);
     }
 
-    private String unprefixKey(String prefix, String key) {
-        if (prefix == null || prefix.isEmpty()) {
-            return key;
-        } else if (!key.startsWith(prefix)) {
-            return key;
-        }
-
-        return key.substring(prefix.length());
-    }
-
-
     private void put(TextMap carrier, String key, String value) {
         carrier.put(keyCodex.encode(key), valueCodex.encode(value));
     }
@@ -87,14 +78,16 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
         final Map<String, String> baggage = new HashMap<>();
 
         for (Map.Entry<String, String> entry : carrier) {
-            final String key = entry.getKey();
-            if (keyCodex.decode(key).startsWith(convention.baggagePrefix())) {
-                baggage.put(unprefixKey(convention.baggagePrefix(), keyCodex.decode(key)), valueCodex.decode(entry.getValue()));
-            } else if (convention.traceIdKeyAliases().contains(keyCodex.decode(key))) {
+            final String decodedKey = keyCodex.decode(entry.getKey()).toLowerCase();
+
+            if (decodedKey.startsWith(convention.baggagePrefix().toLowerCase(Locale.ROOT))) {
+                baggage.put(decodedKey.substring(convention.baggagePrefix().length()),
+                            valueCodex.decode(entry.getValue()));
+            } else if (containsIgnoreCase(convention.traceIdKeyAliases(), decodedKey)) {
                 traceId = valueCodex.decode(entry.getValue());
-            } else if (convention.parentIdKeyAliases().contains(keyCodex.decode(key))) {
+            } else if (containsIgnoreCase(convention.parentIdKeyAliases(), decodedKey)) {
                 parentId = valueCodex.decode(entry.getValue());
-            } else if (convention.spanIdKeyAliases().contains(keyCodex.decode(key))) {
+            } else if (containsIgnoreCase(convention.spanIdKeyAliases(), decodedKey)) {
                 spanId = valueCodex.decode(entry.getValue());
             }
         }
@@ -109,6 +102,10 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
                                               parentId == null ? null : UUID.fromString(parentId),
                                               true);
         return context.addBaggage(baggage);
+    }
+
+    private boolean containsIgnoreCase(Collection<String> strings, String string) {
+        return strings.stream().anyMatch(s -> s.equalsIgnoreCase(string));
     }
 
 
@@ -129,9 +126,7 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
         }
 
         public Builder withCodex(TextMapCodex codex) {
-            this.keyCodex = codex;
-            this.valueCodex = codex;
-            return this;
+            return this.withKeyCodex(codex).withValueCodex(codex);
         }
 
         public Builder withKeyCodex(TextMapCodex codex) {

--- a/core/src/test/java/com/expedia/www/haystack/client/SpanBuilderTest.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/SpanBuilderTest.java
@@ -19,12 +19,10 @@ package com.expedia.www.haystack.client;
 import com.expedia.www.haystack.client.dispatchers.Dispatcher;
 import com.expedia.www.haystack.client.dispatchers.NoopDispatcher;
 import com.expedia.www.haystack.client.metrics.NoopMetricsRegistry;
+import com.expedia.www.haystack.client.propagation.MapBackedTextMap;
 import io.opentracing.References;
 import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
@@ -217,23 +215,5 @@ public class SpanBuilderTest {
         Assert.assertEquals(false, tags.get("boolean-key"));
         Assert.assertTrue(tags.containsKey("number-key"));
         Assert.assertEquals(1l, tags.get("number-key"));
-    }
-
-    private class MapBackedTextMap implements TextMap {
-        private final Map<String, String> map = new HashMap<>();
-
-        @Override
-        public Iterator<Map.Entry<String, String>> iterator() {
-            return map.entrySet().iterator();
-        }
-
-        @Override
-        public void put(String key, String value) {
-            map.put(key, value);
-        }
-
-        public Map<String, String> getMap() {
-            return map;
-        }
     }
 }

--- a/core/src/test/java/com/expedia/www/haystack/client/propagation/MapBackedTextMap.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/propagation/MapBackedTextMap.java
@@ -1,0 +1,28 @@
+package com.expedia.www.haystack.client.propagation;
+
+import io.opentracing.propagation.TextMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public final class MapBackedTextMap implements TextMap {
+    private final Map<String, String> map = new HashMap<>();
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return map.entrySet().iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+        map.put(key, value);
+    }
+
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    public String get(final String key) {
+        return map.get(key);
+    }
+}

--- a/core/src/test/java/com/expedia/www/haystack/client/propagation/TextMapPropagatorTest.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/propagation/TextMapPropagatorTest.java
@@ -1,0 +1,110 @@
+package com.expedia.www.haystack.client.propagation;
+
+import com.expedia.www.haystack.client.SpanContext;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TextMapPropagatorTest {
+    @Test
+    public void propagatorExtractsSpanContextIdentitiesAsExpected() {
+        final KeyConvention keyConvention = new DefaultKeyConvention();
+        final TextMapPropagator propagator = new TextMapPropagator.Builder().withKeyConvention(keyConvention).build();
+        final MapBackedTextMap carrier = new MapBackedTextMap();
+
+        carrier.put(keyConvention.traceIdKey(), "8557731e-cce9-45c2-9485-1fd86f5116ca");
+        carrier.put(keyConvention.spanIdKey(), "30898bb0-f836-43fb-ad69-44969f15e52d");
+        carrier.put(keyConvention.parentIdKey(), "3a0bc1c1-504f-4f5d-907b-9b4522453bcf");
+
+        final SpanContext spanContext = propagator.extract(carrier);
+
+        Assert.assertEquals("trace-id was not extracted correctly",
+                            "8557731e-cce9-45c2-9485-1fd86f5116ca", spanContext.getTraceId().toString());
+        Assert.assertEquals("span-id was not extracted correctly",
+                            "30898bb0-f836-43fb-ad69-44969f15e52d", spanContext.getSpanId().toString());
+        Assert.assertEquals("parent-id was not extracted correctly",
+                            "3a0bc1c1-504f-4f5d-907b-9b4522453bcf", spanContext.getParentId().toString());
+    }
+
+    @Test
+    public void propagatorExtractsSpanContextIdentitiesAsExpectedRegardlessOfCase() {
+        final KeyConvention keyConvention = new DefaultKeyConvention();
+        final TextMapPropagator propagator = new TextMapPropagator.Builder().withKeyConvention(keyConvention).build();
+        final MapBackedTextMap carrier = new MapBackedTextMap();
+
+        carrier.put(keyConvention.traceIdKey().toLowerCase(), "8557731e-cce9-45c2-9485-1fd86f5116ca");
+        carrier.put(keyConvention.spanIdKey().toLowerCase(), "30898bb0-f836-43fb-ad69-44969f15e52d");
+        carrier.put(keyConvention.parentIdKey().toLowerCase(), "3a0bc1c1-504f-4f5d-907b-9b4522453bcf");
+        carrier.put(keyConvention.baggagePrefix().toLowerCase() + "item-1", "foo");
+
+        final SpanContext spanContext = propagator.extract(carrier);
+
+        Assert.assertEquals("trace-id was not extracted correctly",
+                            "8557731e-cce9-45c2-9485-1fd86f5116ca", spanContext.getTraceId().toString());
+        Assert.assertEquals("span-id was not extracted correctly",
+                            "30898bb0-f836-43fb-ad69-44969f15e52d", spanContext.getSpanId().toString());
+        Assert.assertEquals("parent-id was not extracted correctly",
+                            "3a0bc1c1-504f-4f5d-907b-9b4522453bcf", spanContext.getParentId().toString());
+        Assert.assertEquals("baggage item was not extracted correctly",
+                            "foo", spanContext.getBaggage().get("item-1"));
+    }
+
+    @Test
+    public void propagatorInjectsSpanContextIdentitiesAsExpected() {
+        final KeyConvention keyConvention = new DefaultKeyConvention();
+        final TextMapPropagator propagator = new TextMapPropagator.Builder().withKeyConvention(keyConvention).build();
+        final MapBackedTextMap carrier = new MapBackedTextMap();
+
+        final SpanContext spanContext = new SpanContext(UUID.fromString("8557731e-cce9-45c2-9485-1fd86f5116ca"),
+                                                        UUID.fromString("30898bb0-f836-43fb-ad69-44969f15e52d"),
+                                                        UUID.fromString("3a0bc1c1-504f-4f5d-907b-9b4522453bcf"));
+
+        propagator.inject(spanContext, carrier);
+
+        Assert.assertEquals("trace-id was not injected correctly",
+                            "8557731e-cce9-45c2-9485-1fd86f5116ca", carrier.get(keyConvention.traceIdKey()));
+        Assert.assertEquals("span-id was not injected correctly",
+                            "30898bb0-f836-43fb-ad69-44969f15e52d", carrier.get(keyConvention.spanIdKey()));
+        Assert.assertEquals("parent-id was not injected correctly",
+                            "3a0bc1c1-504f-4f5d-907b-9b4522453bcf", carrier.get(keyConvention.parentIdKey()));
+    }
+
+    @Test
+    public void builderUsesTheProvidedCodexForKeyAndValue() {
+        final KeyConvention keyConvention = new DefaultKeyConvention();
+        final TextMapCodex codex = new OneAppendingCodex();
+        final TextMapPropagator propagator = new TextMapPropagator.Builder()
+                .withKeyConvention(keyConvention)
+                .withCodex(codex)
+                .build();
+        final MapBackedTextMap carrier = new MapBackedTextMap();
+
+        final SpanContext spanContext = new SpanContext(UUID.fromString("8557731e-cce9-45c2-9485-1fd86f5116ca"),
+                                                        UUID.fromString("30898bb0-f836-43fb-ad69-44969f15e52d"),
+                                                        UUID.fromString("3a0bc1c1-504f-4f5d-907b-9b4522453bcf"));
+
+        propagator.inject(spanContext, carrier);
+
+        Assert.assertEquals("trace-id was not injected correctly",
+                            "1-8557731e-cce9-45c2-9485-1fd86f5116ca",
+                            carrier.get("1-" + keyConvention.traceIdKey()));
+        Assert.assertEquals("span-id was not injected correctly",
+                            "1-30898bb0-f836-43fb-ad69-44969f15e52d",
+                            carrier.get("1-" + keyConvention.spanIdKey()));
+        Assert.assertEquals("parent-id was not injected correctly",
+                            "1-3a0bc1c1-504f-4f5d-907b-9b4522453bcf",
+                            carrier.get("1-" + keyConvention.parentIdKey()));
+    }
+
+    private class OneAppendingCodex extends  TextMapCodex {
+        @Override
+        public String encode(String value) {
+            return "1-" + value;
+        }
+
+        @Override
+        public String decode(String value) {
+            return value.substring(2);
+        }
+    }
+}


### PR DESCRIPTION
HTTP RFC : https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

```
HTTP header fields, which include general-header (section 4.5), request-header (section 5.3), 
response-header (section 6.2), and entity-header (section 7.1) fields, follow the same generic format 
as that given in Section 3.1 of RFC 822 [9]. Each header field consists of a name followed by a colon
(":") and the field value. *Field names are case-insensitive.*
```

When SpanContext is extracted using `TextMapPropagator`, keys in the carrier can be of different case. In many cases, carrier is `HttpHeadersCarrier` which exposes HTTP headers read from transport. According to RFC, these header names are case insensitive.  Some of the servers and clients do not maintain case of the header provided/read. 