### PR TITLE
RL - Fixing logging message for grpc client on error.

### DIFF
--- a/core/src/main/java/com/expedia/www/haystack/client/dispatchers/clients/BaseGrpcClient.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/dispatchers/clients/BaseGrpcClient.java
@@ -116,7 +116,7 @@ abstract public class BaseGrpcClient<R> implements Client<R> {
         @Override
         public void onError(Throwable t) {
             onErrorCounter.increment();
-            LOGGER.error("Dispatching span failed with error: {}", t);
+            LOGGER.error("Dispatching span failed with error: " + t, t);
         }
 
         @Override


### PR DESCRIPTION
Currently the message being logged when an error occurs in grpc client is:
```
Dispatching span failed with error: {}
```
With the intention that the `{}` will be replaced with the throwable message. However the error has a constructor where a throwable is passed as an argument. As a result, the {} in the message will never get replaced. The idea is to log the error in the simple message, as well as log the stack trace.