### PR TITLE
Updated version to 0.2.9-SNAPSHOT

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-client-java-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>haystack-client-core</artifactId>

--- a/haystack-remote-clients/pom.xml
+++ b/haystack-remote-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expedia.www</groupId>
         <artifactId>haystack-client-java-parent</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>haystack-remote-clients</artifactId>

--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-client-metrics</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/dropwizard-metrics/pom.xml
+++ b/metrics/dropwizard-metrics/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.expedia.www</groupId>
         <artifactId>haystack-client-metrics</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>haystack-client-metrics-dropwizard</artifactId>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.expedia.www</groupId>
         <artifactId>haystack-client-metrics</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>haystack-client-micrometer</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.expedia.www</groupId>
         <artifactId>haystack-client-java-parent</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>haystack-client-metrics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.expedia.www</groupId>
   <artifactId>haystack-client-java-parent</artifactId>
-  <version>0.2.8-SNAPSHOT</version>
+  <version>0.2.9-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Haystack Java Client Parent POM</name>
   <description>Haystack Java Client Parent POM</description>


### PR DESCRIPTION
As part of the release of version `0.2.8` the version number should have been incremented to `0.2.9-SNAPSHOT`. 

Resolves issue #107 