### PR TITLE
Draft proposal to bring ids closer to b3 spec

### DIFF
--- a/core/src/main/java/com/expedia/www/haystack/client/Tracer.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/Tracer.java
@@ -288,7 +288,7 @@ public class Tracer implements io.opentracing.Tracer {
 
         protected SpanContext createNewContext() {
 
-            return createContext(tracer.idGenerator.generate(), tracer.idGenerator.generate(), null, Collections.emptyMap());
+            return createContext(tracer.idGenerator.generateTraceId(), tracer.idGenerator.generateSpanId(), null, Collections.emptyMap());
         }
 
         protected SpanContext createContext(UUID traceId, UUID spanId, UUID parentId, Map<String, String> baggage) {
@@ -331,7 +331,7 @@ public class Tracer implements io.opentracing.Tracer {
             }
 
             return createContext(parent.getContext().getTraceId(),
-                    tracer.idGenerator.generate(),
+                    tracer.idGenerator.generateSpanId(),
                     parent.getContext().getSpanId(),
                     baggage);
         }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/IdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/IdGenerator.java
@@ -17,7 +17,25 @@
 package com.expedia.www.haystack.client.idgenerators;
 
 public interface IdGenerator {
-    Object generateTraceId();
 
-    Object generateSpanId();
+    /**
+     * Generates a unique id
+     * @deprecated This method was deprecated in 0.3.1. Use {@link #generateTraceId()}  and {@link #generateSpanId()} instead
+     */
+    @Deprecated
+    Object generate();
+
+    /**
+     * Generates a random unique identifier for a trace.
+     */
+    default Object generateTraceId() {
+        return generate();
+    }
+
+    /**
+     * Generates a random identifier for a span. It should be unique within a trace.
+     */
+    default Object generateSpanId() {
+        return generate();
+    }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/IdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/IdGenerator.java
@@ -17,5 +17,7 @@
 package com.expedia.www.haystack.client.idgenerators;
 
 public interface IdGenerator {
-    Object generate();
+    Object generateTraceId();
+
+    Object generateSpanId();
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/LongIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/LongIdGenerator.java
@@ -16,20 +16,15 @@
  */
 package com.expedia.www.haystack.client.idgenerators;
 
-
-import com.expedia.www.haystack.client.idgenerators.IdGenerator;
-
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Generates random and unique Longs as ids for Traces and Spans.
+ */
 public class LongIdGenerator implements IdGenerator {
 
     @Override
-    public Long generateTraceId() {
-        return ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
-    }
-
-    @Override
-    public Long generateSpanId() {
+    public Long generate() {
         return ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/LongIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/LongIdGenerator.java
@@ -24,7 +24,12 @@ import java.util.concurrent.ThreadLocalRandom;
 public class LongIdGenerator implements IdGenerator {
 
     @Override
-    public Long generate() {
+    public Long generateTraceId() {
+        return ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    }
+
+    @Override
+    public Long generateSpanId() {
         return ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
@@ -19,10 +19,20 @@ package com.expedia.www.haystack.client.idgenerators;
 
 import java.util.UUID;
 
+/**
+ * Generates UUIDs as ids for Traces and Spans.
+ * <p/>
+ * Given that the span only needs to be unique within a trace, the UUID for spans will only contain the least
+ * significant bits and will be left padded with zeroes.
+ * <p/>
+ * Consider using the TimeBasedUUIDGenerator which is more performant.
+ * <p/>
+ * @see com.expedia.www.haystack.client.idgenerators.TimeBasedUUIDGenerator
+ */
 public class RandomUUIDGenerator implements IdGenerator {
 
     @Override
-    public UUID generateTraceId() {
+    public UUID generate() {
         return UUID.randomUUID();
     }
 

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
@@ -22,11 +22,8 @@ import java.util.UUID;
 /**
  * Generates UUIDs as ids for Traces and Spans.
  * <p/>
- * Given that the span only needs to be unique within a trace, the UUID for spans will only contain the least
- * significant bits and will be left padded with zeroes.
- * <p/>
  * Consider using the TimeBasedUUIDGenerator which is more performant.
- * <p/>
+ *
  * @see com.expedia.www.haystack.client.idgenerators.TimeBasedUUIDGenerator
  */
 public class RandomUUIDGenerator implements IdGenerator {
@@ -34,10 +31,5 @@ public class RandomUUIDGenerator implements IdGenerator {
     @Override
     public UUID generate() {
         return UUID.randomUUID();
-    }
-
-    @Override
-    public UUID generateSpanId() {
-        return new UUID(0, UUID.randomUUID().getLeastSignificantBits());
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/RandomUUIDGenerator.java
@@ -22,7 +22,12 @@ import java.util.UUID;
 public class RandomUUIDGenerator implements IdGenerator {
 
     @Override
-    public UUID generate() {
+    public UUID generateTraceId() {
         return UUID.randomUUID();
+    }
+
+    @Override
+    public UUID generateSpanId() {
+        return new UUID(0, UUID.randomUUID().getLeastSignificantBits());
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
@@ -21,11 +21,15 @@ import com.fasterxml.uuid.Generators;
 
 import java.util.UUID;
 
-
 public class TimeBasedUUIDGenerator implements IdGenerator {
 
     @Override
-    public UUID generate() {
+    public UUID generateTraceId() {
+        return Generators.timeBasedGenerator().generate();
+    }
+
+    @Override
+    public Object generateSpanId() {
         return Generators.timeBasedGenerator().generate();
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
@@ -16,26 +16,17 @@
  */
 package com.expedia.www.haystack.client.idgenerators;
 
-
 import java.util.UUID;
 
 import static com.fasterxml.uuid.Generators.timeBasedGenerator;
 
 /**
  * Generates UUIDs as ids for Traces and Spans.
- * <p/>
- * Given that the span only needs to be unique within a trace, the UUID for spans will only contain the least
- * significant bits and will be left padded with zeroes.
  */
 public class TimeBasedUUIDGenerator implements IdGenerator {
 
     @Override
     public UUID generate() {
         return timeBasedGenerator().generate();
-    }
-
-    @Override
-    public UUID generateSpanId() {
-        return new UUID(0, timeBasedGenerator().generate().getLeastSignificantBits());
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/TimeBasedUUIDGenerator.java
@@ -17,19 +17,25 @@
 package com.expedia.www.haystack.client.idgenerators;
 
 
-import com.fasterxml.uuid.Generators;
-
 import java.util.UUID;
 
+import static com.fasterxml.uuid.Generators.timeBasedGenerator;
+
+/**
+ * Generates UUIDs as ids for Traces and Spans.
+ * <p/>
+ * Given that the span only needs to be unique within a trace, the UUID for spans will only contain the least
+ * significant bits and will be left padded with zeroes.
+ */
 public class TimeBasedUUIDGenerator implements IdGenerator {
 
     @Override
-    public UUID generateTraceId() {
-        return Generators.timeBasedGenerator().generate();
+    public UUID generate() {
+        return timeBasedGenerator().generate();
     }
 
     @Override
-    public Object generateSpanId() {
-        return Generators.timeBasedGenerator().generate();
+    public UUID generateSpanId() {
+        return new UUID(0, timeBasedGenerator().generate().getLeastSignificantBits());
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/propagation/Codex.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/propagation/Codex.java
@@ -40,4 +40,19 @@ public interface Codex<R,T> {
      */
     T decode(R value);
 
+    default T decodeTraceId(R value) {
+        return decode(value);
+    }
+
+    default T decodeSpanId(R value) {
+        return decode(value);
+    }
+
+    default T decodeBaggage(R value) {
+        return decode(value);
+    }
+
+    default T decodeKey(R value) {
+        return decode(value);
+    }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/propagation/TextMapPropagator.java
@@ -78,18 +78,18 @@ public class TextMapPropagator implements Injector<TextMap>, Extractor<TextMap> 
         final Map<String, String> baggage = new HashMap<>();
 
         for (Map.Entry<String, String> entry : carrier) {
-            final String decodedKey = keyCodex.decode(entry.getKey());
+            final String decodedKey = keyCodex.decodeKey(entry.getKey());
             final String decodedKeyLowerCase = decodedKey.toLowerCase();
 
             if (decodedKeyLowerCase.startsWith(convention.baggagePrefix().toLowerCase(Locale.ROOT))) {
                 baggage.put(decodedKey.substring(convention.baggagePrefix().length()),
-                            valueCodex.decode(entry.getValue()));
+                            valueCodex.decodeBaggage(entry.getValue()));
             } else if (containsIgnoreCase(convention.traceIdKeyAliases(), decodedKeyLowerCase)) {
-                traceId = valueCodex.decode(entry.getValue());
+                traceId = valueCodex.decodeTraceId(entry.getValue());
             } else if (containsIgnoreCase(convention.parentIdKeyAliases(), decodedKeyLowerCase)) {
-                parentId = valueCodex.decode(entry.getValue());
+                parentId = valueCodex.decodeSpanId(entry.getValue());
             } else if (containsIgnoreCase(convention.spanIdKeyAliases(), decodedKeyLowerCase)) {
-                spanId = valueCodex.decode(entry.getValue());
+                spanId = valueCodex.decodeSpanId(entry.getValue());
             }
         }
 

--- a/core/src/test/java/com/expedia/www/haystack/client/TracerPropagationTest.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/TracerPropagationTest.java
@@ -43,9 +43,9 @@ public class TracerPropagationTest {
     @Test(expected=IllegalArgumentException.class)
     public void testInjectInvalidFormat() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         String carrier = "";
 
@@ -58,9 +58,9 @@ public class TracerPropagationTest {
     @Test
     public void testInject() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         TextMapAdapter carrier = new TextMapAdapter(carrierValues);
@@ -80,9 +80,9 @@ public class TracerPropagationTest {
     @Test
     public void testInjectURLEncoded() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         TextMap carrier = new TextMapAdapter(carrierValues);
@@ -103,9 +103,9 @@ public class TracerPropagationTest {
     @Test
     public void testExtract() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         carrierValues.put("Baggage-TEST", "TEXT");
@@ -128,9 +128,9 @@ public class TracerPropagationTest {
     @Test
     public void testExtractIgnoreUnknowns() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         carrierValues.put("Trace-ID", traceId.toString());
@@ -153,8 +153,8 @@ public class TracerPropagationTest {
     @Test
     public void testExtractInvalid() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         carrierValues.put("Span-ID", spanId.toString());
@@ -171,9 +171,9 @@ public class TracerPropagationTest {
     @Test
     public void testExtractURLEncoded() {
         IdGenerator idGenerator = new RandomUUIDGenerator();
-        Object traceId = idGenerator.generate();
-        Object spanId = idGenerator.generate();
-        Object parentId = idGenerator.generate();
+        Object traceId = idGenerator.generateTraceId();
+        Object spanId = idGenerator.generateSpanId();
+        Object parentId = idGenerator.generateTraceId();
 
         Map<String, String> carrierValues = new HashMap<>();
         carrierValues.put("Baggage-TEST", "!%40%23%23*%5E%20%25%5E%26%26(*");

--- a/core/src/test/java/com/expedia/www/haystack/client/dispatchers/clients/HttpCollectorClientTest.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/dispatchers/clients/HttpCollectorClientTest.java
@@ -38,7 +38,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -47,8 +46,8 @@ public class HttpCollectorClientTest {
 
     private Tracer tracer;
     private final static String serviceName = "dummy-service";
-    private final static Object traceId = new RandomUUIDGenerator().generate();
-    private final static Object spanId = new RandomUUIDGenerator().generate();
+    private final static Object traceId = new RandomUUIDGenerator().generateTraceId();
+    private final static Object spanId = new RandomUUIDGenerator().generateSpanId();
     private final static SpanContext spanContext = new SpanContext(traceId, spanId, null);
 
     @Before


### PR DESCRIPTION
### Motivation
This pr is an attempt to bring the UUID and B3 formats closer.

Even though we can use B3 with haystack we may still have interop problems when two different services are using B3 / UUIDs.

Part of this can be addressed by normalizing these ids in Haystack, or at ingestion time in Pitchfork or using some other proxy. But we're still left with problems when we try to stitch spans together.

This is a complex problem and will require several changes. This change is one of many but I think will move us one step closer to create a better interop.

### Changes
This pr tries to address the problem of the formats for the span id and the possible loss of data when converting between a UUID and a b3 span id.

It's easy to build a mechanism, to convert between uuids and longs by stripping or adding dashes. There will be scenarios where the UUID doesn't actually conform to the specs but it still meets the goal of representing an unique id.

However a span is half the size needed so we can only do this mapping by preserving either the most or leas significant bytes.

Ie, the UUID cb58f5d0-1cf8-11ea-978f-2e728ce88125 can not be converted into a b3 span id without loss of data.

This pr changes the generation of span ids so that the msb part can be dropped without loss of data, for example something like this: 00000000-0000-0000-960a-56c5d6ca2ec8, which can then be converted into a b3 span id: 960a56c5d6ca2ec8