### PR TITLE
Adding B3 compatible hexchar id generator

### DIFF
--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -32,11 +32,22 @@ public class HexcharIdGenerator implements IdGenerator {
 
     @Override
     public String generateSpanId() {
-        return String.format("%016X", random.nextLong());
+        return String.format("%016X", next64BitId());
     }
 
     @Override
     public Object generate() {
         return null;
+    }
+
+    /**
+     * Generates a new 64-bit id, taking care to dodge zero which can be confused with absent
+     */
+    private long next64BitId() {
+        long nextId = random.nextLong();
+        while (nextId == 0L) {
+            nextId = random.nextLong();
+        }
+        return nextId;
     }
 }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.client.idgenerators;
+
+import java.util.Random;
+
+/**
+ * Generates random and unique B3 compatible hexchar ids.
+ * Note that traceId will be in 128 bit while spanId and parentSpanId will be 64 bit.
+ */
+public class HexcharIdGenerator implements IdGenerator {
+    private final Random random = new Random();
+
+    @Override
+    public String generateTraceId() {
+        return String.format("%016X", random.nextLong()).concat(String.format("%016X", random.nextLong()));
+    }
+
+    @Override
+    public String generateSpanId() {
+        return String.format("%016X", random.nextLong());
+    }
+
+    @Override
+    public Object generate() {
+        return null;
+    }
+}

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -43,9 +43,9 @@ public class HexcharIdGenerator implements IdGenerator {
      * Generates a new 64-bit id, taking care to dodge zero which can be confused with absent
      */
     private long nextRandomLong() {
-        long nextId = ThreadLocalRandom.current().nextLong();
+        long nextId = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
         while (nextId == 0L) {
-            nextId = ThreadLocalRandom.current().nextLong();
+            nextId = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
         }
         return nextId;
     }

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -36,7 +36,7 @@ public class HexcharIdGenerator implements IdGenerator {
 
     @Override
     public Object generate() {
-        return null;
+        return String.format("%016X", nextRandomLong()).concat(String.format("%016X", nextRandomLong()));
     }
 
     /**

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -27,12 +27,12 @@ public class HexcharIdGenerator implements IdGenerator {
 
     @Override
     public String generateTraceId() {
-        return String.format("%016X", random.nextLong()).concat(String.format("%016X", random.nextLong()));
+        return String.format("%016X", nextRandomLong()).concat(String.format("%016X", nextRandomLong()));
     }
 
     @Override
     public String generateSpanId() {
-        return String.format("%016X", next64BitId());
+        return String.format("%016X", nextRandomLong());
     }
 
     @Override
@@ -43,7 +43,7 @@ public class HexcharIdGenerator implements IdGenerator {
     /**
      * Generates a new 64-bit id, taking care to dodge zero which can be confused with absent
      */
-    private long next64BitId() {
+    private long nextRandomLong() {
         long nextId = random.nextLong();
         while (nextId == 0L) {
             nextId = random.nextLong();

--- a/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
+++ b/core/src/main/java/com/expedia/www/haystack/client/idgenerators/HexcharIdGenerator.java
@@ -16,14 +16,13 @@
  */
 package com.expedia.www.haystack.client.idgenerators;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Generates random and unique B3 compatible hexchar ids.
  * Note that traceId will be in 128 bit while spanId and parentSpanId will be 64 bit.
  */
 public class HexcharIdGenerator implements IdGenerator {
-    private final Random random = new Random();
 
     @Override
     public String generateTraceId() {
@@ -44,9 +43,9 @@ public class HexcharIdGenerator implements IdGenerator {
      * Generates a new 64-bit id, taking care to dodge zero which can be confused with absent
      */
     private long nextRandomLong() {
-        long nextId = random.nextLong();
+        long nextId = ThreadLocalRandom.current().nextLong();
         while (nextId == 0L) {
-            nextId = random.nextLong();
+            nextId = ThreadLocalRandom.current().nextLong();
         }
         return nextId;
     }

--- a/core/src/test/java/com/expedia/www/haystack/client/TracerBuildTest.java
+++ b/core/src/test/java/com/expedia/www/haystack/client/TracerBuildTest.java
@@ -17,6 +17,7 @@
 package com.expedia.www.haystack.client;
 
 import com.expedia.www.haystack.client.dispatchers.NoopDispatcher;
+import com.expedia.www.haystack.client.idgenerators.HexcharIdGenerator;
 import com.expedia.www.haystack.client.idgenerators.IdGenerator;
 import com.expedia.www.haystack.client.idgenerators.LongIdGenerator;
 import com.expedia.www.haystack.client.idgenerators.RandomUUIDGenerator;
@@ -64,5 +65,13 @@ public class TracerBuildTest {
         Assert.assertNotNull(tracer);
     }
 
+    @Test
+    public void testTracerBuildHexcharIdGenerator(){
+        IdGenerator idGenerator = new HexcharIdGenerator();
+        Tracer.Builder tracerBuild = new Tracer.Builder(new NoopMetricsRegistry(), "TestTracer", new NoopDispatcher());
+        tracerBuild.withIdGenerator(idGenerator);
+        Tracer tracer = tracerBuild.build();
+        Assert.assertNotNull(tracer);
+    }
 
 }


### PR DESCRIPTION
In continuation to the PR #113 , adding a B3 compatible hexchar id generator.

Generated traceId will be 128 bit while spanId and parentSpanId will be 64 bit.